### PR TITLE
SAP-2475: Add EC2 IAM drift guard and stage HTTP placeholder support

### DIFF
--- a/internal/cmd/tofu.go
+++ b/internal/cmd/tofu.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MetroStar/quartzctl/internal/provider"
 	"github.com/MetroStar/quartzctl/internal/log"
 	"github.com/MetroStar/quartzctl/internal/stages"
 	"github.com/MetroStar/quartzctl/internal/tofu"
@@ -561,6 +562,11 @@ func TfApply(ctx context.Context, stage string, p *CommandParams) error {
 		return err
 	}
 
+	err = failOnEc2IamStateDrift(ctx, stage, p, client)
+	if err != nil {
+		return err
+	}
+
 	err = wrapChecks(ctx, stage, "apply", p, func() error {
 		s := p.Settings().Config.Stages[stage]
 		return client.Apply(ctx, s, tofu.TofuApplyOpts{AllowDeferral: p.allowDeferral})
@@ -576,6 +582,92 @@ func TfApply(ctx context.Context, stage string, p *CommandParams) error {
 	}
 	util.Msgf("Stage %s completed in %v", stage, time.Since(stageStart).Round(time.Second))
 	return nil
+}
+
+func failOnEc2IamStateDrift(ctx context.Context, stage string, p *CommandParams, client *tofu.TofuClient) error {
+	if !strings.EqualFold(stage, "ec2") {
+		return nil
+	}
+
+	cp, err := p.Provider().Cloud(ctx)
+	if err != nil {
+		log.Debug("Skipping ec2 IAM drift guard: cloud provider unavailable", "stage", stage, "error", err)
+		return nil
+	}
+
+	awsClient, ok := cp.(provider.AwsClient)
+	if !ok {
+		return nil
+	}
+
+	s := p.Settings().Config.Stages[stage]
+	addresses, err := client.StateList(ctx, s)
+	if err != nil {
+		log.Debug("Skipping ec2 IAM drift guard: failed to read stage state", "stage", stage, "error", err)
+		return nil
+	}
+
+	roleTracked := stateHasAddressSuffix(addresses, "aws_iam_role.server")
+	profileTracked := stateHasAddressSuffix(addresses, "aws_iam_instance_profile.server")
+	if roleTracked && profileTracked {
+		return nil
+	}
+
+	cluster := p.Settings().Config.Name
+	roleExists, profileExists, err := awsClient.Ec2ServerIdentityExists(ctx, cluster)
+	if err != nil {
+		log.Debug("Skipping ec2 IAM drift guard: failed to inspect IAM role/profile", "stage", stage, "cluster", cluster, "error", err)
+		return nil
+	}
+
+	return ec2IamStateDriftError(stage, cluster, roleTracked, profileTracked, roleExists, profileExists)
+}
+
+func stateHasAddressSuffix(addresses []string, suffix string) bool {
+	for _, addr := range addresses {
+		if strings.HasSuffix(addr, suffix) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ec2IamStateDriftError(stage string, cluster string, roleTracked bool, profileTracked bool, roleExists bool, profileExists bool) error {
+	if (roleTracked || !roleExists) && (profileTracked || !profileExists) {
+		return nil
+	}
+
+	roleName := fmt.Sprintf("%s-server-role", cluster)
+	profileName := fmt.Sprintf("%s-server-profile", cluster)
+
+	var missingState []string
+	if !roleTracked {
+		missingState = append(missingState, "aws_iam_role.server")
+	}
+	if !profileTracked {
+		missingState = append(missingState, "aws_iam_instance_profile.server")
+	}
+
+	var existingAws []string
+	if roleExists {
+		existingAws = append(existingAws, roleName)
+	}
+	if profileExists {
+		existingAws = append(existingAws, profileName)
+	}
+
+	return fmt.Errorf(
+		"stage %s blocked before apply: detected IAM state drift/orphaned resources. Missing in OpenTofu state: %s. Existing in AWS: %s. "+
+			"This usually causes EntityAlreadyExists during apply after a destroy/recreate attempt. Reconcile before continuing: "+
+			"(1) import resources into state (quartz tofu import -s %s aws_iam_role.server %s and quartz tofu import -s %s aws_iam_instance_profile.server %s), "+
+			"or (2) delete orphaned IAM resources if they are safe to recreate.",
+		stage,
+		strings.Join(missingState, ", "),
+		strings.Join(existingAws, ", "),
+		stage, roleName,
+		stage, profileName,
+	)
 }
 
 // TfApplyTargeted runs `tofu apply` for a stage restricted to the given resource

--- a/internal/cmd/tofu.go
+++ b/internal/cmd/tofu.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MetroStar/quartzctl/internal/provider"
 	"github.com/MetroStar/quartzctl/internal/log"
+	"github.com/MetroStar/quartzctl/internal/provider"
 	"github.com/MetroStar/quartzctl/internal/stages"
 	"github.com/MetroStar/quartzctl/internal/tofu"
 	"github.com/MetroStar/quartzctl/internal/util"
@@ -661,7 +661,7 @@ func ec2IamStateDriftError(stage string, cluster string, roleTracked bool, profi
 		"stage %s blocked before apply: detected IAM state drift/orphaned resources. Missing in OpenTofu state: %s. Existing in AWS: %s. "+
 			"This usually causes EntityAlreadyExists during apply after a destroy/recreate attempt. Reconcile before continuing: "+
 			"(1) import resources into state (quartz tofu import -s %s aws_iam_role.server %s and quartz tofu import -s %s aws_iam_instance_profile.server %s), "+
-			"or (2) delete orphaned IAM resources if they are safe to recreate.",
+			"or (2) delete orphaned IAM resources if they are safe to recreate",
 		stage,
 		strings.Join(missingState, ", "),
 		strings.Join(existingAws, ", "),

--- a/internal/cmd/tofu_test.go
+++ b/internal/cmd/tofu_test.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -364,4 +365,31 @@ func runTestTfCommandWithStage(t *testing.T, cmd *cli.Command) {
 	assert.Error(t, err) // Missing required flag
 
 	runTestTfCommand(t, cmd, "-s", "first")
+}
+
+func TestEc2IamStateDriftError_NoDrift(t *testing.T) {
+	err := ec2IamStateDriftError("ec2", "sapphire-demo", true, true, true, true)
+	assert.NoError(t, err)
+}
+
+func TestEc2IamStateDriftError_ReportsRoleDrift(t *testing.T) {
+	err := ec2IamStateDriftError("ec2", "sapphire-demo", false, true, true, true)
+	if assert.Error(t, err) {
+		assert.True(t, strings.Contains(err.Error(), "IAM state drift/orphaned resources"))
+		assert.True(t, strings.Contains(err.Error(), "aws_iam_role.server"))
+		assert.True(t, strings.Contains(err.Error(), "sapphire-demo-server-role"))
+	}
+}
+
+func TestEc2IamStateDriftError_ReportsProfileDrift(t *testing.T) {
+	err := ec2IamStateDriftError("ec2", "sapphire-demo", true, false, true, true)
+	if assert.Error(t, err) {
+		assert.True(t, strings.Contains(err.Error(), "aws_iam_instance_profile.server"))
+		assert.True(t, strings.Contains(err.Error(), "sapphire-demo-server-profile"))
+	}
+}
+
+func TestEc2IamStateDriftError_MissingInStateButAbsentInAws(t *testing.T) {
+	err := ec2IamStateDriftError("ec2", "sapphire-demo", false, false, false, false)
+	assert.NoError(t, err)
 }

--- a/internal/provider/aws.go
+++ b/internal/provider/aws.go
@@ -16,6 +16,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 )
 
 const (
@@ -251,6 +253,45 @@ func (c AwsClient) PrepareAccount(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// Ec2ServerIdentityExists reports whether the standard ec2 stage IAM role and
+// instance profile already exist for the given cluster name.
+func (c AwsClient) Ec2ServerIdentityExists(ctx context.Context, cluster string) (bool, bool, error) {
+	roleName := cluster + "-server-role"
+	profileName := cluster + "-server-profile"
+
+	roleExists := false
+	_, roleErr := c.sdk.Iam().GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if roleErr == nil {
+		roleExists = true
+	} else if !isIamNotFoundError(roleErr) {
+		return false, false, roleErr
+	}
+
+	profileExists := false
+	_, profileErr := c.sdk.Iam().GetInstanceProfile(ctx, &iam.GetInstanceProfileInput{InstanceProfileName: aws.String(profileName)})
+	if profileErr == nil {
+		profileExists = true
+	} else if !isIamNotFoundError(profileErr) {
+		return false, false, profileErr
+	}
+
+	return roleExists, profileExists, nil
+}
+
+func isIamNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		return strings.EqualFold(apiErr.ErrorCode(), "NoSuchEntity") || strings.EqualFold(apiErr.ErrorCode(), "NoSuchEntityException")
+	}
+
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "nosuchentity") || strings.Contains(errStr, "cannot be found")
 }
 
 // ------------- end ICloudProviderClient -------------

--- a/internal/provider/aws_mocks_test.go
+++ b/internal/provider/aws_mocks_test.go
@@ -56,6 +56,8 @@ type StsClientMock struct {
 type IamClientMock struct {
 	err            error
 	accountAliases []string
+	roleExists      bool
+	profileExists   bool
 }
 
 // S3ClientMock provides a mock implementation of the S3 client.
@@ -143,6 +145,30 @@ func (c IamClientMock) ListAccountAliases(ctx context.Context, params *iam.ListA
 // CreateServiceLinkedRole returns a mock response for the CreateServiceLinkedRole API call.
 func (c IamClientMock) CreateServiceLinkedRole(ctx context.Context, params *iam.CreateServiceLinkedRoleInput, optFns ...func(*iam.Options)) (*iam.CreateServiceLinkedRoleOutput, error) {
 	return &iam.CreateServiceLinkedRoleOutput{}, c.err
+}
+
+// GetRole returns a mock response for the GetRole API call.
+func (c IamClientMock) GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	if !c.roleExists {
+		return nil, fmt.Errorf("NoSuchEntity")
+	}
+
+	return &iam.GetRoleOutput{}, nil
+}
+
+// GetInstanceProfile returns a mock response for the GetInstanceProfile API call.
+func (c IamClientMock) GetInstanceProfile(ctx context.Context, params *iam.GetInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	if !c.profileExists {
+		return nil, fmt.Errorf("NoSuchEntity")
+	}
+
+	return &iam.GetInstanceProfileOutput{}, nil
 }
 
 // HeadBucket returns a mock response for the HeadBucket API call.

--- a/internal/provider/aws_mocks_test.go
+++ b/internal/provider/aws_mocks_test.go
@@ -56,8 +56,8 @@ type StsClientMock struct {
 type IamClientMock struct {
 	err            error
 	accountAliases []string
-	roleExists      bool
-	profileExists   bool
+	roleExists     bool
+	profileExists  bool
 }
 
 // S3ClientMock provides a mock implementation of the S3 client.

--- a/internal/provider/aws_sdk.go
+++ b/internal/provider/aws_sdk.go
@@ -59,6 +59,8 @@ type StsClient interface {
 type IamClient interface {
 	ListAccountAliases(ctx context.Context, params *iam.ListAccountAliasesInput, optFns ...func(*iam.Options)) (*iam.ListAccountAliasesOutput, error)
 	CreateServiceLinkedRole(ctx context.Context, params *iam.CreateServiceLinkedRoleInput, optFns ...func(*iam.Options)) (*iam.CreateServiceLinkedRoleOutput, error)
+	GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	GetInstanceProfile(ctx context.Context, params *iam.GetInstanceProfileInput, optFns ...func(*iam.Options)) (*iam.GetInstanceProfileOutput, error)
 }
 
 // S3Client defines the interface for interacting with AWS S3.

--- a/internal/stages/http_check.go
+++ b/internal/stages/http_check.go
@@ -121,17 +121,39 @@ func (c HttpStageCheck) RetryOpts() schema.StageChecksRetryConfig {
 // formatUrl constructs the full URL for the HTTP stage check based on the configuration.
 // If no URL is provided, it generates a default URL using the application name and domain.
 func (c HttpStageCheck) formatUrl(cfg schema.QuartzConfig) string {
-	url := c.Url
+	url := expandConfigPlaceholders(c.Url, cfg)
 	if len(url) == 0 {
 		// TODO: move this somewhere reusable
-		baseUrl := fmt.Sprintf("https://%s.%s", c.App, cfg.Dns.Domain)
-		if c.App == "keycloak" {
+		app := expandConfigPlaceholders(c.App, cfg)
+		path := expandConfigPlaceholders(c.Path, cfg)
+		baseUrl := fmt.Sprintf("https://%s.%s", app, cfg.Dns.Domain)
+		if strings.EqualFold(app, "keycloak") {
 			baseUrl = fmt.Sprintf("https://keycloak.auth.%s", cfg.Dns.Domain)
 		}
-		url = baseUrl + c.Path
+		url = baseUrl + path
 	}
 
 	return url
+}
+
+func expandConfigPlaceholders(input string, cfg schema.QuartzConfig) string {
+	if input == "" {
+		return input
+	}
+
+	replacements := map[string]string{
+		"${name}":       cfg.Name,
+		"${aws.region}": cfg.Aws.Region,
+		"${dns.zone}":   cfg.Dns.Zone,
+		"${dns.domain}": cfg.Dns.Domain,
+	}
+
+	output := input
+	for token, value := range replacements {
+		output = strings.ReplaceAll(output, token, value)
+	}
+
+	return output
 }
 
 // checkResponseContent validates the response content against the expected value or JSON key.

--- a/internal/stages/http_check_test.go
+++ b/internal/stages/http_check_test.go
@@ -103,7 +103,12 @@ func TestHttpStageCheckRunNoMatch(t *testing.T) {
 
 func TestHttpStageCheckFormatUrl(t *testing.T) {
 	cfg := schema.QuartzConfig{
+		Name: "sapphire-demo",
+		Aws: schema.AwsConfig{
+			Region: "us-west-2",
+		},
 		Dns: schema.DnsConfig{
+			Zone:   "metrostar.cloud",
 			Domain: "example.com",
 		},
 	}
@@ -116,6 +121,16 @@ func TestHttpStageCheckFormatUrl(t *testing.T) {
 	u2 := HttpStageCheck{App: "keycloak"}.formatUrl(cfg)
 	if u2 != "https://keycloak.auth.example.com" {
 		t.Errorf("invalid response, expected %s, found %s", "https://keycloak.auth.example.com", u2)
+	}
+
+	u3 := HttpStageCheck{Url: "https://ec2.${aws.region}.amazonaws.com"}.formatUrl(cfg)
+	if u3 != "https://ec2.us-west-2.amazonaws.com" {
+		t.Errorf("invalid response, expected %s, found %s", "https://ec2.us-west-2.amazonaws.com", u3)
+	}
+
+	u4 := HttpStageCheck{Url: "https://${name}.${dns.zone}"}.formatUrl(cfg)
+	if u4 != "https://sapphire-demo.metrostar.cloud" {
+		t.Errorf("invalid response, expected %s, found %s", "https://sapphire-demo.metrostar.cloud", u4)
 	}
 }
 


### PR DESCRIPTION
# Pull Request

## 🔍 Description
Implements SAP-2475 reliability improvements for Quartz AWS/tofu workflows.

- Added early EC2 IAM state-drift/orphan detection before apply (role/profile present in AWS but absent in state)
- Added clear remediation guidance in error output for import vs cleanup paths
- Added helper APIs for IAM role/profile existence checks in provider layer
- Added stage HTTP check placeholder support and test coverage
- Added/updated unit tests for drift error behavior and provider/stage logic

Related Jira: https://metrostarsystems.atlassian.net/browse/SAP-2475

## 📋 Checklist
- [x] I have tested this PR locally.
- [x] I have added/updated unit tests where applicable.
- [x] This PR adheres to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] I have run `golangci-lint run` and resolved all issues.
- [x] I have verified this PR does not expose any secrets or sensitive information.
- [x] I have updated documentation (README, CLI help text, etc.) if needed.

## 📦 Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Test or CI/CD improvement
- [x] Refactor or code cleanup
- [ ] Other (describe):

## 🧪 How to Test
1. Run `go test ./...`
2. Run `golangci-lint run`
3. Run `mise run test-ci`

## 📸 Screenshots / Output
- `go test ./...` passes
- `golangci-lint run` passes
- `mise run test-ci` passes

## 🧑‍⚖️ Reviewer Notes
Please focus review on the new state-drift guard path in `internal/cmd/tofu.go` and provider IAM existence probes.